### PR TITLE
struct定義・パラメータの修正

### DIFF
--- a/fields/tweet_fields.go
+++ b/fields/tweet_fields.go
@@ -47,3 +47,12 @@ func (fl TweetFieldList) Values() []string {
 
 	return s
 }
+
+func (fl TweetFieldList) HasContextAnnotations() bool {
+	for _, v := range fl {
+		if v == TweetFieldContextAnnotations {
+			return true
+		}
+	}
+	return false
+}

--- a/resources/fields.go
+++ b/resources/fields.go
@@ -25,7 +25,7 @@ type Media struct {
 	PromotedMetrics  map[string]*int  `json:"promoted_metrics,omitempty"`
 	PublicMetrics    map[string]*int  `json:"public_metrics,omitempty"`
 	Width            *int             `json:"width,omitempty"`
-	AltText          *int             `json:"alt_text,omitempty"`
+	AltText          *string          `json:"alt_text,omitempty"`
 	Variants         []IncludeVariant `json:"variants,omitempty"`
 }
 

--- a/resources/tweet.go
+++ b/resources/tweet.go
@@ -28,7 +28,7 @@ type Tweet struct {
 
 type TweetAttachments struct {
 	MediaKeys []string `json:"media_keys,omitempty"`
-	PollIDs   []string `json:"poll_i_ds,omitempty"`
+	PollIDs   []string `json:"poll_ids,omitempty"`
 }
 
 type ContextAnnotation struct {

--- a/tweet/searchtweet/types/parameter.go
+++ b/tweet/searchtweet/types/parameter.go
@@ -55,6 +55,10 @@ var listRecentQueryParameters = map[string]struct{}{
 }
 
 func (m ListMaxResults) Valid() bool {
+	return m >= 10 && m <= 500
+}
+
+func (m ListMaxResults) ValidWithContextAnnotations() bool {
 	return m >= 10 && m <= 100
 }
 
@@ -121,8 +125,14 @@ func (p *ListRecentInput) ParameterMap() map[string]string {
 		m["until_id"] = p.UntilID
 	}
 
-	if p.MaxResults.Valid() {
-		m["max_results"] = p.MaxResults.String()
+	if p.TweetFields.HasContextAnnotations() {
+		if p.MaxResults.ValidWithContextAnnotations() {
+			m["max_results"] = p.MaxResults.String()
+		}
+	} else {
+		if p.MaxResults.Valid() {
+			m["max_results"] = p.MaxResults.String()
+		}
 	}
 
 	if p.NextToken != "" {
@@ -224,8 +234,14 @@ func (p *ListAllInput) ParameterMap() map[string]string {
 		m["until_id"] = p.UntilID
 	}
 
-	if p.MaxResults.Valid() {
-		m["max_results"] = p.MaxResults.String()
+	if p.TweetFields.HasContextAnnotations() {
+		if p.MaxResults.ValidWithContextAnnotations() {
+			m["max_results"] = p.MaxResults.String()
+		}
+	} else {
+		if p.MaxResults.Valid() {
+			m["max_results"] = p.MaxResults.String()
+		}
 	}
 
 	if p.NextToken != "" {


### PR DESCRIPTION
BUG: qlonolink/qua#18724

- context_annotationsを指定する場合100だが現状のquaには不要と思われるので500取得できるようにする
  - https://github.com/qlonolink/qua/issues/18601#issuecomment-2038983479
  - トレンドとかの分類情報？
- 型やJSONフィールド名の間違いを修正

参考:
https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all