### PR TITLE
filteredstream.ListRulesにページネーションを追加

### DIFF
--- a/resources/meta.go
+++ b/resources/meta.go
@@ -34,7 +34,9 @@ type SpacesLookupTweetsMeta struct {
 }
 
 type ListSearchStreamRulesMeta struct {
-	Sent *time.Time `json:"sent"`
+	Sent        *time.Time `json:"sent"`
+	NextToken   *string    `json:"next_token"`
+	ResultCount *int       `json:"result_count"`
 }
 
 type CreateSearchStreamRulesMeta struct {

--- a/tweet/filteredstream/types/parameter.go
+++ b/tweet/filteredstream/types/parameter.go
@@ -14,7 +14,8 @@ type ListRulesInput struct {
 	accessToken string
 
 	// Query parameters
-	IDs []string
+	IDs             []string
+	PaginationToken string
 }
 
 var listRulesQueryParameters = map[string]struct{}{
@@ -49,6 +50,10 @@ func (p *ListRulesInput) ParameterMap() map[string]string {
 
 	if p.IDs != nil && len(p.IDs) > 0 {
 		m["ids"] = util.QueryValue(p.IDs)
+	}
+
+	if p.PaginationToken != "" {
+		m["pagination_token"] = p.PaginationToken
 	}
 
 	return m


### PR DESCRIPTION
BUG: qlonolink/qua#19027

- ドキュメントにはページネーションが載っていないがレスポンスには存在する
  - https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream-rules

#### 検証

qua_sme(868), qua_amuse(252)を登録