### PR TITLE
Rule取得のQueryParameterの設定漏れ

### DIFF
--- a/tweet/filteredstream/types/parameter.go
+++ b/tweet/filteredstream/types/parameter.go
@@ -19,7 +19,8 @@ type ListRulesInput struct {
 }
 
 var listRulesQueryParameters = map[string]struct{}{
-	"ids": {},
+	"ids":              {},
+	"pagination_token": {},
 }
 
 func (p *ListRulesInput) SetAccessToken(token string) {


### PR DESCRIPTION
BUG: qlonolink/qua#19027

- ParameterMapを返すだけじゃなく、listRulesQueryParametersにも設定が必要だった