### PR TITLE
TweetTimelineについて不足しているfields, response定義を追加

### DIFF
--- a/fields/tweet_fields.go
+++ b/fields/tweet_fields.go
@@ -24,6 +24,8 @@ const (
 	TweetFieldReferencedTweets    TweetField = "referenced_tweets"
 	TweetFieldReplySettings       TweetField = "reply_settings"
 	TweetFieldWithheld            TweetField = "withheld"
+	TweetFieldGeo                 TweetField = "geo"
+	TweetFieldSource              TweetField = "source"
 )
 
 func (f TweetField) String() string {

--- a/resources/tweet.go
+++ b/resources/tweet.go
@@ -5,6 +5,7 @@ import "time"
 type Tweet struct {
 	ID                  *string             `json:"id"`
 	Text                *string             `json:"text"`
+	EditControls        *EditControls       `json:"edit_controls,omitempty"`
 	EditHistoryTweetIDs []*string           `json:"edit_history_tweet_ids"`
 	Attachments         *TweetAttachments   `json:"attachments,omitempty"`
 	AuthorID            *string             `json:"author_id,omitempty"`
@@ -101,6 +102,7 @@ type Geo struct {
 }
 
 type NonPublicMetrics struct {
+	Engagements       *int `json:"engagements"`
 	ImpressionCount   *int `json:"impression_count"`
 	UrlLinkClicks     *int `json:"url_link_clicks"`
 	UserProfileClicks *int `json:"user_profile_clicks"`
@@ -141,4 +143,10 @@ type ReferencedTweet struct {
 type TweetWithheld struct {
 	Copyright    *bool     `json:"copyright"`
 	CountryCodes []*string `json:"country_codes"`
+}
+
+type EditControls struct {
+	EditRemaining  *int       `json:"edit_remaining"`
+	IsEditEligible *bool      `json:"is_edit_eligible"`
+	EditableUntil  *time.Time `json:"editable_until"`
 }


### PR DESCRIPTION
BUG: qlonolink/qua#22676

https://github.com/qlonolink/qua/issues/22712#issuecomment-2510449898 を元に現状の定義と比較して不足しているものを追加します

- fields
  - geo
  - source
- response
  - edit_controls
  - non_public_metrics.engagements